### PR TITLE
Update util.js to export template function

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -9,6 +9,7 @@ const _ = require('lodash');
 
 const engineUtil = require('../core/lib/engine_util');
 const renderVariables = engineUtil._renderVariables;
+const template = engineUtil.template;
 
 module.exports = {
   readScript,
@@ -17,7 +18,8 @@ module.exports = {
   addOverrides,
   addVariables,
   checkConfig,
-  renderVariables
+  renderVariables,
+  template
 };
 
 function readScript(scriptPath, callback) {


### PR DESCRIPTION
This is required for `artillery-plugin-expect`

Same fix as in https://github.com/Nordstrom/artillery/pull/7